### PR TITLE
[closes #2] - Uses affection status of parents to make it a bit more strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 // NOTE: See this: https://github.com/brentp/slivar#how-it-works
 
+// NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
+// ES5 defaults in functions
+
 function allelic_balance_high_quality(sample) {
   // This function ensures that the allelic balance observed
   // is what is expected for given zygosity
@@ -9,50 +12,28 @@ function allelic_balance_high_quality(sample) {
 }
 
 function high_quality(sample, depth, gq) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (depth == undefined) {
-    depth = 5
-  }
-  if (gq == undefined) {
-    gq = 30
-  }
-
+  if (depth == undefined) depth = 5
+  if (gq == undefined) gq = 30
   return sample.DP > depth && sample.GQ > gq
 }
 
 function uniparental_disomy(proband, mom, dad) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (mom == undefined) {
-    mom = {}
-  }
-  if (dad == undefined) {
-    dad = {}
-  }
-
+  if (mom == undefined) mom = {}
+  if (dad == undefined) dad = {}
   return (
     (proband.alts == 0 || proband.alts == 2) && ((mom.alts == 2 && dad.alts == 0) || (mom.alts == 0 && dad.alts == 2))
   )
 }
 
 function denovo(proband, mom, dad) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (mom == undefined) {
-    mom = {}
-  }
-  if (dad == undefined) {
-    dad = {}
-  }
+  if (mom == undefined) mom = {}
+  if (dad == undefined) dad = {}
+
+  if (mom.affected || dad.affected) return false
 
   if (proband.alts == 1) {
-    if (mom.alts != undefined && mom.alts != 0) {
-      return false
-    }
-    if (dad.alts != undefined && dad.alts != 0) {
-      return false
-    }
+    if (mom.alts != undefined && mom.alts != 0) return false
+    if (dad.alts != undefined && dad.alts != 0) return false
   } else {
     return false
   }
@@ -61,25 +42,15 @@ function denovo(proband, mom, dad) {
 }
 
 function x_linked_denovo(proband, mom, dad) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (mom == undefined) {
-    mom = {}
-  }
-  if (dad == undefined) {
-    dad = {}
-  }
+  if (mom == undefined) mom = {}
+  if (dad == undefined) dad = {}
+
+  if (mom.affected || dad.affected) return false
 
   if (proband.alts >= 1) {
-    if (proband.sex != undefined && proband.sex != 'male') {
-      return false
-    }
-    if (mom.alts != undefined && mom.alts != 0) {
-      return false
-    }
-    if (dad.alts != undefined && dad.alts != 0) {
-      return false
-    }
+    if (proband.sex != undefined && proband.sex != 'male') return false
+    if (mom.alts != undefined && mom.alts != 0) return false
+    if (dad.alts != undefined && dad.alts != 0) return false
   } else {
     return false
   }
@@ -88,22 +59,14 @@ function x_linked_denovo(proband, mom, dad) {
 }
 
 function homozygous_recessive(proband, mom, dad) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (mom == undefined) {
-    mom = {}
-  }
-  if (dad == undefined) {
-    dad = {}
-  }
+  if (mom == undefined) mom = {}
+  if (dad == undefined) dad = {}
+
+  if (mom.affected || dad.affected) return false
 
   if (proband.alts == 2) {
-    if (mom.alts != undefined && mom.alts == 0) {
-      return false
-    }
-    if (dad.alts != undefined && dad.alts == 0) {
-      return false
-    }
+    if (mom.alts != undefined && mom.alts != 1) return false
+    if (dad.alts != undefined && dad.alts != 1) return false
   } else {
     return false
   }
@@ -112,25 +75,15 @@ function homozygous_recessive(proband, mom, dad) {
 }
 
 function x_linked_homozygous_recessive(proband, mom, dad) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (mom == undefined) {
-    mom = {}
-  }
-  if (dad == undefined) {
-    dad = {}
-  }
+  if (mom == undefined) mom = {}
+  if (dad == undefined) dad = {}
+
+  if (mom.affected || dad.affected) return false
 
   if (proband.alts >= 1) {
-    if (proband.sex != undefined && proband.sex != 'male') {
-      return false
-    }
-    if (mom.alts != undefined && mom.alts == 0) {
-      return false
-    }
-    if (dad.alts != undefined && dad.alts != 0) {
-      return false
-    }
+    if (proband.sex != undefined && proband.sex != 'male') return false
+    if (mom.alts != undefined && mom.alts == 0) return false
+    if (dad.alts != undefined && dad.alts != 0) return false
   } else {
     return false
   }
@@ -142,22 +95,14 @@ function compound_heterozygous_side(proband, mom, dad) {
   // NOTE: this identifies if a variant is potentially a compound heterozygous
   // NOTE: This is the 1st half, it then needs to run through slivar comphets to do in-phase transmission
 
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (mom == undefined) {
-    mom = {}
-  }
-  if (dad == undefined) {
-    dad = {}
-  }
+  if (mom == undefined) mom = {}
+  if (dad == undefined) dad = {}
+
+  if (mom.affected || dad.affected) return false
 
   if (proband.alts == 1) {
-    if (mom.alts != undefined && mom.alts == 0) {
-      return false
-    }
-    if (dad.alts != undefined && dad.alts == 0) {
-      return false
-    }
+    if (mom.alts != undefined && mom.alts != 1) return false
+    if (dad.alts != undefined && dad.alts != 1) return false
   } else {
     return false
   }
@@ -169,58 +114,36 @@ function remove_compound_heterozygous_side(INFO, key) {
   // NOTE: this is useful for removing all the intermediate comphet side variants
   // after running slivar comp-hets
 
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
   if (key == undefined) key = 'compound_heterozygous_side'
 
-  if (key in INFO) {
-    return false
-  } else {
-    return true
-  }
+  if (key in INFO) return false
+  else return true
 }
 
 function in_hgmd(INFO, key, position) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (key == undefined) {
-    key = 'CSQ'
-  }
-  if (position == undefined) {
-    position = 28
-  }
-  if (!(key in INFO)) {
-    return false
-  }
+  if (key == undefined) key = 'CSQ'
+  if (position == undefined) position = 28
 
-  let impact = false
+  if (!(key in INFO)) return false
+
+  var impact = false
   const effects = INFO[key].split(',')
   effects.forEach(function(effect) {
     const data = effect.split('|')
-    if (data[position]) {
-      impact = true
-    }
+    if (data[position]) impact = true
   })
 
   return impact
 }
 
 function nonsynonymous(INFO, key, position) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (key == undefined) {
-    key = 'CSQ'
-  }
-  if (position == undefined) {
-    position = 1
-  }
-  if (!(key in INFO)) {
-    return false
-  }
+  if (key == undefined) key = 'CSQ'
+  if (position == undefined) position = 1
+  if (!(key in INFO)) return false
 
-  const types = ['missense', 'splice', 'insertion', 'deletion', 'frameshift', 'stop', 'start', 'coding sequence']
+  const types = ['missense', 'splice', 'insertion', 'devarion', 'frameshift', 'stop', 'start', 'coding sequence']
 
-  let impact = false
+  var impact = false
   const effects = INFO[key].split(',')
   effects.forEach(function(effect) {
     const data = effect.split('|')
@@ -234,30 +157,17 @@ function nonsynonymous(INFO, key, position) {
 }
 
 function cohort_af(INFO, key, position, cutoff) {
-  // NOTE: Sets up default values. Since ducktape is using basic JS, we can't use
-  // ES5 defaults in functions
-  if (key == undefined) {
-    key = 'CSQ'
-  }
-  if (position == undefined) {
-    position = 35
-  }
-  if (cutoff == undefined) {
-    cutoff = 0.01
-  }
-  if (!(key in INFO)) {
-    return false
-  }
+  if (key == undefined) key = 'CSQ'
+  if (position == undefined) position = 35
+  if (cutoff == undefined) cutoff = 0.01
+  if (!(key in INFO)) return false
 
-  let impact = false
+  var impact = false
   const effects = INFO[key].split(',')
   effects.forEach(function(effect) {
     const data = effect.split('|')
-    if (typeof data[position] == 'undefined') {
-      impact = true
-    } else if (data[position] <= parseFloat(cutoff)) {
-      impact = true
-    }
+    if (typeof data[position] == 'undefined') impact = true
+    else if (data[position] <= parseFloat(cutoff)) impact = true
   })
 
   return impact

--- a/index.test.js
+++ b/index.test.js
@@ -55,7 +55,9 @@ test.each([
   ['denovo: parents are both homozygous REF', { alts: 1 }, { alts: 0 }, { alts: 0 }, true],
   ['denovo: proband is homozygous', { alts: 2 }, { alts: 0 }, { alts: 0 }, false],
   ['denovo: mom is heterozygous', { alts: 1 }, { alts: 1 }, { alts: 0 }, false],
+  ['denovo: mom is affected', { alts: 1 }, { alts: 0, affected: true }, { alts: 0 }, false],
   ['denovo: dad is heterozygous', { alts: 1 }, { alts: 0 }, { alts: 1 }, false],
+  ['denovo: dad is affected', { alts: 1 }, { alts: 0 }, { alts: 0, affected: true }, false],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
   expect(denovo(kid, mom, dad)).toBe(expected)
 })
@@ -68,7 +70,9 @@ test.each([
   ['x_linked_denovo: proband is homozygous', { alts: 2 }, { alts: 0 }, { alts: 0 }, true],
   ['x_linked_denovo: proband is female', { alts: 1, sex: 'female' }, { alts: 0 }, { alts: 0 }, false],
   ['x_linked_denovo: mom is heterozygous', { alts: 1, sex: 'male' }, { alts: 1 }, { alts: 0 }, false],
+  ['x_linked_denovo: mom is affected', { alts: 1, sex: 'male' }, { alts: 0, affected: true }, { alts: 0 }, false],
   ['x_linked_denovo: dad is hemizygous', { alts: 1, sex: 'male' }, { alts: 0 }, { alts: 1 }, false],
+  ['x_linked_denovo: dad is affected', { alts: 1, sex: 'male' }, { alts: 0 }, { alts: 0, affected: true }, false],
   ['x_linked_denovo: proband is homozygous REF', { alts: 0, sex: 'male' }, { alts: 0 }, { alts: 1 }, false],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
   expect(x_linked_denovo(kid, mom, dad)).toBe(expected)
@@ -77,8 +81,8 @@ test.each([
 test.each([
   ['homozygous_recessive: can handle missing parents', { alts: 2 }, undefined, undefined, true],
   ['homozygous_recessive: mom is heterozygous and dad is heterozygous', { alts: 2 }, { alts: 1 }, { alts: 1 }, true],
-  ['homozygous_recessive: mom is homozygous and dad is heterozygous', { alts: 2 }, { alts: 2 }, { alts: 1 }, true],
-  ['homozygous_recessive: mom is heterozygous and dad is homozygous', { alts: 2 }, { alts: 1 }, { alts: 2 }, true],
+  ['homozygous_recessive: mom is homozygous and dad is heterozygous', { alts: 2 }, { alts: 2 }, { alts: 1 }, false],
+  ['homozygous_recessive: mom is heterozygous and dad is homozygous', { alts: 2 }, { alts: 1 }, { alts: 2 }, false],
   ['homozygous_recessive: proband is heterozygous', { alts: 1 }, { alts: 1 }, { alts: 2 }, false],
   ['homozygous_recessive: proband is reference', { alts: 0 }, { alts: 1 }, { alts: 2 }, false],
   [
@@ -89,10 +93,24 @@ test.each([
     false,
   ],
   [
+    'homozygous_recessive: proband is homozygous but mom is affected',
+    { alts: 2 },
+    { alts: 1, affected: true },
+    { alts: 1 },
+    false,
+  ],
+  [
     'homozygous_recessive: proband is homozygous but dad is homozygous REF',
     { alts: 2 },
     { alts: 1 },
     { alts: 0 },
+    false,
+  ],
+  [
+    'homozygous_recessive: proband is homozygous but dad is affected',
+    { alts: 2 },
+    { alts: 1 },
+    { alts: 1, affected: true },
     false,
   ],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
@@ -126,6 +144,8 @@ test.each([
     { alts: 0 },
     false,
   ],
+  ['x_linked_homozygous_recessive: mom is affected', { alts: 1 }, { alts: 1, affected: true }, { alts: 0 }, false],
+  ['x_linked_homozygous_recessive: dad is affected', { alts: 1 }, { alts: 1 }, { alts: 0, affected: true }, false],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
   expect(x_linked_homozygous_recessive(kid, mom, dad)).toBe(expected)
 })
@@ -144,14 +164,14 @@ test.each([
     { alts: 1 },
     { alts: 2 },
     { alts: 1 },
-    true,
+    false,
   ],
   [
     'compound_heterozygous_side: mom is heterozygous and dad is homozygous',
     { alts: 1 },
     { alts: 1 },
     { alts: 2 },
-    true,
+    false,
   ],
   ['compound_heterozygous_side: mom and dad are both homozygous REF', { alts: 1 }, { alts: 0 }, { alts: 0 }, false],
   [
@@ -166,6 +186,20 @@ test.each([
     { alts: 1 },
     { alts: 0 },
     undefined,
+    false,
+  ],
+  [
+    'compound_heterozygous_side: mom is heterozygous and dad is heterozygous, but mom is affected',
+    { alts: 1 },
+    { alts: 1, affected: true },
+    { alts: 1 },
+    false,
+  ],
+  [
+    'compound_heterozygous_side: mom is heterozygous and dad is heterozygous, but dad is affected',
+    { alts: 1 },
+    { alts: 1 },
+    { alts: 1, affected: true },
     false,
   ],
   ['compound_heterozygous_side: proband is not heterozygous', { alts: 0 }, { alts: 0 }, undefined, false],


### PR DESCRIPTION
Resolves #2 

+ Uses parents affection status to only apply MOI if it makes sense
+ Made usage of genotypes a bit more strict