### PR TITLE
[closes #7] - Ensures de-novo is only called when both parents are available

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,8 @@ function dominant(proband, mom, dad) {
 }
 
 function denovo(proband, mom, dad) {
-  if (mom == undefined) mom = {}
-  if (dad == undefined) dad = {}
+  if (mom == undefined) return false
+  if (dad == undefined) return false
 
   if (mom.affected || dad.affected) return false
 

--- a/index.test.js
+++ b/index.test.js
@@ -57,8 +57,8 @@ test.each([
 })
 
 test.each([
-  ['denovo: can handle missing parents', { alts: 1 }, { alts: 0 }, undefined, true],
-  ['denovo: can handle missing parents', { alts: 1 }, undefined, undefined, true],
+  ['denovo: can handle missing parents', { alts: 1 }, { alts: 0 }, undefined, false],
+  ['denovo: can handle missing parents', { alts: 1 }, undefined, undefined, false],
   ['denovo: parents are both homozygous REF', { alts: 1 }, { alts: 0 }, { alts: 0 }, true],
   ['denovo: proband is homozygous', { alts: 2 }, { alts: 0 }, { alts: 0 }, false],
   ['denovo: mom is heterozygous', { alts: 1 }, { alts: 1 }, { alts: 0 }, false],


### PR DESCRIPTION
Resolves #7 