### PR TITLE
[closes #15] - Relax the use of parental affection status in segregation rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,6 @@ function denovo(proband, mom, dad) {
   if (mom == undefined) return false
   if (dad == undefined) return false
 
-  if (mom.affected || dad.affected) return false
-
   if (proband.alts == 1) {
     if (mom.alts != undefined && mom.alts != 0) return false
     if (dad.alts != undefined && dad.alts != 0) return false
@@ -66,8 +64,6 @@ function denovo(proband, mom, dad) {
 function x_linked_denovo(proband, mom, dad) {
   if (mom == undefined) mom = {}
   if (dad == undefined) dad = {}
-
-  if (mom.affected || dad.affected) return false
 
   if (proband.alts >= 1) {
     if (proband.sex != undefined && proband.sex != 'male') return false
@@ -84,8 +80,6 @@ function homozygous_recessive(proband, mom, dad) {
   if (mom == undefined) mom = {}
   if (dad == undefined) dad = {}
 
-  if (mom.affected || dad.affected) return false
-
   if (proband.alts == 2) {
     if (mom.alts != undefined && mom.alts != 1) return false
     if (dad.alts != undefined && dad.alts != 1) return false
@@ -99,8 +93,6 @@ function homozygous_recessive(proband, mom, dad) {
 function x_linked_homozygous_recessive(proband, mom, dad) {
   if (mom == undefined) mom = {}
   if (dad == undefined) dad = {}
-
-  if (mom.affected || dad.affected) return false
 
   if (proband.alts >= 1) {
     if (proband.sex != undefined && proband.sex != 'male') return false
@@ -119,8 +111,6 @@ function compound_heterozygous_side(proband, mom, dad) {
 
   if (mom == undefined) mom = {}
   if (dad == undefined) dad = {}
-
-  if (mom.affected || dad.affected) return false
 
   if (proband.alts == 1) {
     if (mom.alts != undefined && mom.alts == 2) return false

--- a/index.test.js
+++ b/index.test.js
@@ -63,9 +63,7 @@ test.each([
   ['denovo: parents are both homozygous REF', { alts: 1 }, { alts: 0 }, { alts: 0 }, true],
   ['denovo: proband is homozygous', { alts: 2 }, { alts: 0 }, { alts: 0 }, false],
   ['denovo: mom is heterozygous', { alts: 1 }, { alts: 1 }, { alts: 0 }, false],
-  ['denovo: mom is affected', { alts: 1 }, { alts: 0, affected: true }, { alts: 0 }, false],
   ['denovo: dad is heterozygous', { alts: 1 }, { alts: 0 }, { alts: 1 }, false],
-  ['denovo: dad is affected', { alts: 1 }, { alts: 0 }, { alts: 0, affected: true }, false],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
   expect(denovo(kid, mom, dad)).toBe(expected)
 })
@@ -147,9 +145,7 @@ test.each([
   ['x_linked_denovo: proband is homozygous', { alts: 2 }, { alts: 0 }, { alts: 0 }, true],
   ['x_linked_denovo: proband is female', { alts: 1, sex: 'female' }, { alts: 0 }, { alts: 0 }, false],
   ['x_linked_denovo: mom is heterozygous', { alts: 1, sex: 'male' }, { alts: 1 }, { alts: 0 }, false],
-  ['x_linked_denovo: mom is affected', { alts: 1, sex: 'male' }, { alts: 0, affected: true }, { alts: 0 }, false],
   ['x_linked_denovo: dad is hemizygous', { alts: 1, sex: 'male' }, { alts: 0 }, { alts: 1 }, false],
-  ['x_linked_denovo: dad is affected', { alts: 1, sex: 'male' }, { alts: 0 }, { alts: 0, affected: true }, false],
   ['x_linked_denovo: proband is homozygous REF', { alts: 0, sex: 'male' }, { alts: 0 }, { alts: 1 }, false],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
   expect(x_linked_denovo(kid, mom, dad)).toBe(expected)
@@ -170,24 +166,10 @@ test.each([
     false,
   ],
   [
-    'homozygous_recessive: proband is homozygous but mom is affected',
-    { alts: 2 },
-    { alts: 1, affected: true },
-    { alts: 1 },
-    false,
-  ],
-  [
     'homozygous_recessive: proband is homozygous but dad is homozygous REF',
     { alts: 2 },
     { alts: 1 },
     { alts: 0 },
-    false,
-  ],
-  [
-    'homozygous_recessive: proband is homozygous but dad is affected',
-    { alts: 2 },
-    { alts: 1 },
-    { alts: 1, affected: true },
     false,
   ],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
@@ -221,8 +203,6 @@ test.each([
     { alts: 0 },
     false,
   ],
-  ['x_linked_homozygous_recessive: mom is affected', { alts: 1 }, { alts: 1, affected: true }, { alts: 0 }, false],
-  ['x_linked_homozygous_recessive: dad is affected', { alts: 1 }, { alts: 1 }, { alts: 0, affected: true }, false],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
   expect(x_linked_homozygous_recessive(kid, mom, dad)).toBe(expected)
 })
@@ -253,20 +233,6 @@ test.each([
   ['compound_heterozygous_side: mom and dad are both homozygous REF', { alts: 1 }, { alts: 0 }, { alts: 0 }, true],
   ['compound_heterozygous_side: mom is undefined and dad is homozygous REF', { alts: 1 }, undefined, { alts: 0 }, true],
   ['compound_heterozygous_side: dad is undefined and mom is homozygous REF', { alts: 1 }, { alts: 0 }, undefined, true],
-  [
-    'compound_heterozygous_side: mom is heterozygous and dad is heterozygous, but mom is affected',
-    { alts: 1 },
-    { alts: 1, affected: true },
-    { alts: 1 },
-    false,
-  ],
-  [
-    'compound_heterozygous_side: mom is heterozygous and dad is heterozygous, but dad is affected',
-    { alts: 1 },
-    { alts: 1 },
-    { alts: 1, affected: true },
-    false,
-  ],
   ['compound_heterozygous_side: proband is not heterozygous', { alts: 0 }, { alts: 0 }, undefined, false],
 ])('%s: Kid: %j Mom: %j Dad: %j equals %p', (a, kid, mom, dad, expected) => {
   expect(compound_heterozygous_side(kid, mom, dad)).toBe(expected)


### PR DESCRIPTION
Relaxed segregation rules to not use affection status in all except AD.  See #15 for more details.