### PR TITLE
VEP sometimes annotation may have more than 1 value seperated by '&'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,10 @@ function match_filter(INFO, key, position, types) {
     const data = effect.split('|')
     const element = data[position]
     types.forEach(function(type) {
-      if (element == type) result = true
+      const values = splitVEPItem(element)
+      values.forEach(function(value) {
+        if (value == type) result = true
+      })
     })
   })
 
@@ -237,8 +240,9 @@ function gte_filter(INFO, key, position, cutoff) {
     if (!data[position]) impact = false
     else {
       const scores = []
-      data[position].split('&').forEach(function(score) {
-        scores.push(parseFloat(score))
+      const values = splitVEPItem(data[position])
+      values.forEach(function(value) {
+        scores.push(parseFloat(value))
       })
       const score = Math.max.apply(null, scores)
       if (score >= parseFloat(cutoff)) impact = true
@@ -261,8 +265,9 @@ function lte_filter(INFO, key, position, cutoff) {
     if (!data[position]) impact = false
     else {
       const scores = []
-      data[position].split('&').forEach(function(score) {
-        scores.push(parseFloat(score))
+      const values = splitVEPItem(data[position])
+      values.forEach(function(value) {
+        scores.push(parseFloat(value))
       })
       const score = Math.min.apply(null, scores)
       if (score <= parseFloat(cutoff)) impact = true
@@ -283,10 +288,22 @@ function maf_filter(INFO, key, position, cutoff) {
   effects.forEach(function(effect) {
     const data = effect.split('|')
     if (!data[position]) impact = true
-    else if (parseFloat(data[position]) <= parseFloat(cutoff)) impact = true
+    else {
+      const scores = []
+      const values = splitVEPItem(data[position])
+      values.forEach(function(score) {
+        scores.push(parseFloat(score))
+      })
+      const score = Math.min.apply(null, scores)
+      if (score <= parseFloat(cutoff)) impact = true
+    }
   })
 
   return impact
+}
+
+function splitVEPItem(data) {
+  return data.split('&')
 }
 
 module.exports = {
@@ -310,4 +327,5 @@ module.exports = {
   gte_filter,
   lte_filter,
   maf_filter,
+  splitVEPItem,
 }

--- a/index.test.js
+++ b/index.test.js
@@ -18,6 +18,7 @@ const { match_filter } = require('./index')
 const { gte_filter } = require('./index')
 const { lte_filter } = require('./index')
 const { maf_filter } = require('./index')
+const { splitVEPItem } = require('./index')
 
 test.each([
   ['allelic_balance_high_quality: homozygous REF with high AB', { alts: 0, AB: 0.2 }, false],
@@ -640,6 +641,22 @@ test.each([
     ['frameshift'],
     true,
   ],
+  [
+    'match_filter: can handle mutliple values',
+    { BSQ: '||frameshift2&frameshift||||||||||||||||||||||||||||||||||' },
+    'BSQ',
+    2,
+    ['frameshift'],
+    true,
+  ],
+  [
+    'match_filter: can handle mutliple values',
+    { BSQ: '||frameshift2&frameshift3||||||||||||||||||||||||||||||||||' },
+    'BSQ',
+    2,
+    ['frameshift'],
+    false,
+  ],
 ])('%s: %j key: %s position: %s types: %j equals %p', (a, info, key, position, types, expected) => {
   expect(match_filter(info, key, position, types)).toBe(expected)
 })
@@ -775,4 +792,11 @@ test.each([
   ],
 ])('%s: %j key: %s position: %s cutoff: %s equals %p', (a, info, key, position, cutoff, expected) => {
   expect(maf_filter(info, key, position, cutoff)).toBe(expected)
+})
+
+test.each([
+  ['splitVEPItem: can split 1 item', 'item1', ['item1']],
+  ['splitVEPItem: can split 1 item', 'item1&item2', ['item1', 'item2']],
+])('%s: %s equals %j', (a, observed, expected) => {
+  expect(splitVEPItem(observed)).toEqual(expected)
 })


### PR DESCRIPTION
Splitting by that delimiter prevents unexpected results